### PR TITLE
docs: add Erron AI company and contact links

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,7 @@ python -m unittest discover -s tests -v
 
 ## Status
 This repository is initialized as part of the Erron AI multi-repo launch and is intentionally production-minded while remaining extensible for deeper roadmap features.
+
+## Company and Contact
+- Built and maintained by [Erron AI](https://erron.ai).
+- Contact: [info@erron.ai](mailto:info@erron.ai)

--- a/docs/HOMEBREW.md
+++ b/docs/HOMEBREW.md
@@ -9,3 +9,5 @@ agent-security-playbook --help
 ```
 
 A formal tap/formula can be added after stable release artifacts are published.
+
+Maintained by [Erron AI](https://erron.ai). Contact: [info@erron.ai](mailto:info@erron.ai)


### PR DESCRIPTION
## Summary
- add linked company attribution in README/docs
- add linked contact email in README/docs
- keep changes docs-only and non-breaking

## Validation
- reviewed README.md and docs markdown files
- ensured links use https://erron.ai and mailto
