### PR TITLE
docs: hyperlink built-by attribution in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Security best practices for prompt injection, supply chain risk, data leakage, and access control.
 
-Built by **erron.ai**.
+Built by [Erron AI](https://erron.ai).
 
 ## Why this exists
 - Solve a concrete business problem with a practical, extensible baseline.


### PR DESCRIPTION
## Summary
- replace plain `Built by **erron.ai**.` with a hyperlink
- keep README wording intact while making attribution clickable

## Validation
- verified README includes `Built by [Erron AI](https://erron.ai).`
