### PR TITLE
chore: migrate quickstart to uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Built by [Erron AI](https://erron.ai).
 
 ## Quickstart
 ```bash
-python3 -m venv .venv
+uv venv .venv
 source .venv/bin/activate
-pip install -e .
+uv pip install -e .
 python -m agent_security_playbook.cli --help
 python -m unittest discover -s tests -v
 ```


### PR DESCRIPTION
## Summary
- Update README quickstart to use uv (`uv venv .venv`, `uv pip install -e .`).
- Preserve existing activation/run/test commands.

## Test plan
- Verify README quickstart commands reflect uv-based setup.
- Confirm no production code changes.
